### PR TITLE
Allow all the ascii characters except ";" for the host description 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "evernode-js-client",
-    "version": "0.3.5",
+    "version": "0.3.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "evernode-js-client",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "scripts": {
         "lint": "./node_modules/.bin/eslint src/**/*.js",
         "build": "npm run lint && ncc build src/index.js -e elliptic -e xrpl -e ripple-address-codec -e ripple-keypairs -o dist/",

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -55,13 +55,12 @@ class HostClient extends BaseEvernodeClient {
             throw "ramMb should be a positive intiger";
         else if (!diskMb || isNaN(diskMb) || diskMb % 1 != 0 || diskMb < 0)
             throw "diskMb should be a positive intiger";
-        /* eslint-disable no-control-regex */
         // Need to use control characters inside this regex to match ascii characters.
-        // Here we allow all the characters in ascii rage except ";" for the description.
-        // no-control-regex is enabled default by eslint:recommended, So we disable it only for this block.
+        // Here we allow all the characters in ascii range except ";" for the description.
+        // no-control-regex is enabled default by eslint:recommended, So we disable it only for next line.
+        // eslint-disable-next-line no-control-regex
         else if (!/^((?![;])[\x00-\x7F]){0,26}$/.test(description))
             throw "description should consist of 0-26 ascii characters except ';'";
-        /* eslint-enable no-control-regex */
 
         if (await this.isRegistered())
             throw "Host already registered.";

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -57,6 +57,7 @@ class HostClient extends BaseEvernodeClient {
             throw "diskMb should be a positive intiger";
         /* eslint-disable no-control-regex */
         // Need to use control characters inside this regex to match ascii characters.
+        // Here we allow all the characters in ascii rage except ";" for the description.
         // no-control-regex is enabled default by eslint:recommended, So we disable it only for this block.
         else if (!/^((?![;])[\x00-\x7F]){0,26}$/.test(description))
             throw "description should consist of 0-26 ascii characters except ';'";

--- a/src/clients/host-client.js
+++ b/src/clients/host-client.js
@@ -55,8 +55,12 @@ class HostClient extends BaseEvernodeClient {
             throw "ramMb should be a positive intiger";
         else if (!diskMb || isNaN(diskMb) || diskMb % 1 != 0 || diskMb < 0)
             throw "diskMb should be a positive intiger";
-        else if (!/^([a-zA-Z\s]{0,26})$/.test(description))
-            throw "description should consist of 0-26 alphabetical characters";
+        /* eslint-disable no-control-regex */
+        // Need to use control characters inside this regex to match ascii characters.
+        // no-control-regex is enabled default by eslint:recommended, So we disable it only for this block.
+        else if (!/^((?![;])[\x00-\x7F]){0,26}$/.test(description))
+            throw "description should consist of 0-26 ascii characters except ';'";
+        /* eslint-enable no-control-regex */
 
         if (await this.isRegistered())
             throw "Host already registered.";


### PR DESCRIPTION
- Allow all the characters in the ascii range fir the host description
- Do not allow ; since it's used as a delimiter when sending host metadata to the hook
